### PR TITLE
Optimisations in parallelisation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust_geodistances"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # `rust_geodistances` Library
 
+> ## **Documentation**:
+>
+> **Available at [github pages](https://denwong47.github.io/rust_geodistances/).**
+
 Faster great-circle pair-wise calculations for Latitude-Longitude numpy arrays.
 
 Typically, great-circle distances in python are done via ``scikit-learn`` [haversine_distances](https://scikit-learn.org/stable/modules/generated/sklearn.metrics.pairwise.haversine_distances.html#sklearn.metrics.pairwise.haversine_distances) which is written in [Cython](https://github.com/scikit-learn/scikit-learn/blob/ecb9a70e82d4ee352e2958c555536a395b53d2bd/sklearn/metrics/_dist_metrics.pyx.tp#L2620).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "rust_geodistances"
 authors = [
     {name = "Denny Wong Pui-chung", email = "denwong47@hotmail.com"},
 ]
-version = "0.2.0"
+version = "0.2.1"
 description = "Python Library with a Rust backend to calculate Geodistances using both Haversine and Vincenty methods."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/src/py/rust_geodistances/__init__.py
+++ b/src/py/rust_geodistances/__init__.py
@@ -24,18 +24,14 @@ haversine = bin.CalculationMethod.HAVERSINE
 """
 Enum instance containing Haversine calculations methods.
 
-Use:
-
-- :func:`haversine.distance`
-- :func:`haversine.distance_from_point`
+.. seealso::
+  See :class:`CalculationMethod` for all inherited methods.
 """
 
 vincenty = bin.CalculationMethod.VINCENTY
 """
 Enum instance containing Vincenty calculations methods.
 
-Use:
-
-- :func:`vincenty.distance`
-- :func:`vincenty.distance_from_point`
+.. seealso::
+  See :class:`CalculationMethod` for all inherited methods.
 """

--- a/src/rust/calc_models/haversine.rs
+++ b/src/rust/calc_models/haversine.rs
@@ -244,6 +244,8 @@ impl<__impl_generics__> OffsetByVector<__vector_type__> for Haversine {
     [ &F64ArrayViewMut<'a, Ix1> ]   [ 'a ];
 )]
 impl<__impl_generics__> CheckDistance<__vector_type__> for Haversine {
+    /// .. versionchanged: 0.2.1
+    ///     Not in use anymore; this is now done at enum level.
     fn within_distance_of_point(
         s:&dyn LatLng,
         e:&dyn LatLngArray,
@@ -253,6 +255,8 @@ impl<__impl_generics__> CheckDistance<__vector_type__> for Haversine {
         return (Self::distance_from_point(s, e, settings,) - distance).le(&0.);
     }
 
+    /// .. versionchanged: 0.2.1
+    ///     Not in use anymore; this is now done at enum level.
     fn within_distance(
         s:&dyn LatLngArray,
         e:&dyn LatLngArray,

--- a/src/rust/calc_models/traits.rs
+++ b/src/rust/calc_models/traits.rs
@@ -35,8 +35,8 @@ use ndarray_numeric::{
 use super::config;
 
 // Marker Trait definitions for the common parameter types
-pub trait LatLng : ArrayWithF64AngularMethods<Ix1> + Index<Ix, Output = f64> {}
-pub trait LatLngArray : ArrayWithF64LatLngMethods + Index<Dim<[Ix; 2]>, Output = f64> {}
+pub trait LatLng : ArrayWithF64AngularMethods<Ix1> + Index<Ix, Output = f64> + Sync {}
+pub trait LatLngArray : ArrayWithF64LatLngMethods + Index<Dim<[Ix; 2]>, Output = f64> + Sync {}
 
 #[duplicate_item(
     __latlng_type__;

--- a/src/rust/calc_models/vincenty.rs
+++ b/src/rust/calc_models/vincenty.rs
@@ -356,6 +356,8 @@ impl CalculateDistance for Vincenty {
     [ &F64ArrayViewMut<'a, Ix1> ]   [ 'a ];
 )]
 impl<__impl_generics__> CheckDistance<__vector_type__> for Vincenty {
+    /// .. versionchanged: 0.2.1
+    ///     Not in use anymore; this is now done at enum level.
     fn within_distance_of_point(
         s:&dyn LatLng,
         e:&dyn LatLngArray,
@@ -365,6 +367,8 @@ impl<__impl_generics__> CheckDistance<__vector_type__> for Vincenty {
         return (Self::distance_from_point(s, e, settings,) - distance).le(&0.);
     }
 
+    /// .. versionchanged: 0.2.1
+    ///     Not in use anymore; this is now done at enum level.
     fn within_distance(
         s:&dyn LatLngArray,
         e:&dyn LatLngArray,

--- a/src/rust/compatibility/python.rs
+++ b/src/rust/compatibility/python.rs
@@ -289,6 +289,10 @@ impl enums::CalculationMethod {
     #[pyo3(text_signature = "($self, s, e, distance, *, settings)")]
     /// Check if array of lat-long coordinates is within great-circle distance of point.
     ///
+    /// .. versionchanged:: 0.2.1
+    ///     This function was renamed from :func:`within_distance_from_point` to
+    ///     :func:`within_distance_of_point`.
+    ///
     /// Parameters
     /// ----------
     /// s: numpy.ndarray
@@ -317,7 +321,7 @@ impl enums::CalculationMethod {
     ///     Dimension `(n)`.
     ///     An array of great-circle distances mapping each point in
     ///     `e` to `s`.
-    fn within_distance_from_point(
+    fn within_distance_of_point(
         &self,
         s: &PyArray<f64, Ix1>,
         e: &PyArray<f64, Ix2>,


### PR DESCRIPTION
- `distance_from_point` and `within_distance_of_point` are now parallelised.
- `distance` and `within_distance` will now check the dimensions of incoming arrays, and run the parallelisation in the fast orientation, then transpose the results if necessary.
- Renamed method `within_distance_from_point` to `within_distance_of_point`.